### PR TITLE
Feature/update server to rdf4j 3.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,9 +130,9 @@
             indicated in branding.properties (module st-console) -->
         <karaf.version>4.3.0</karaf.version>
 
-        <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
+        <maven-bundle-plugin.version>5.1.2</maven-bundle-plugin.version>
         <osgi.version>7.0.0</osgi.version>
-        <osgi.compendium.version>7.0.0</osgi.compendium.version>
+        <osgi.compendium.version>6.0.0</osgi.compendium.version>
         <pax.exam.version>4.13.4</pax.exam.version>
         <awaitility.version>3.1.6</awaitility.version>
         <junit.version>4.13.1</junit.version>
@@ -145,7 +145,7 @@
         <commons.fileupload.version>1.4</commons.fileupload.version>
         <commons.io.version>2.8.0</commons.io.version>
         <commons.codec.version>1.14</commons.codec.version>
-        <commons.lang3.version>3.11</commons.lang3.version>
+        <commons.lang3.version>3.12.0</commons.lang3.version>
         <commons.text.version>1.9</commons.text.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-collections.version>3.2.2</commons-collections.version>
@@ -159,7 +159,7 @@
         <jts.core.version>1.18.1</jts.core.version>
 
         <servlet.version>3.1.0</servlet.version>
-        <guava.version>29.0-jre</guava.version>
+        <guava.version>30.1-jre</guava.version>
         <failureaccess.version>1.0.1</failureaccess.version>
 
         <slf4j.version>1.7.30</slf4j.version>
@@ -184,7 +184,7 @@
 
         <lucene.version>7.7.1</lucene.version>
         <solr.version>7.7.1</solr.version>
-        <elasticsearch.version>6.8.14</elasticsearch.version>
+        <elasticsearch.version>6.6.2</elasticsearch.version>
         <netty.version>4.1.32.Final</netty.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -1,280 +1,328 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>ru.agentlab.rdf4j</groupId>
-	<artifactId>ru.agentlab.rdf4j.parent</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
-	<packaging>pom</packaging>
-	
-	<name>Agentlab RDF4J Parent</name>
-	<description>Agentlab RDF4J REST Server Parent Pom</description>
+    <groupId>ru.agentlab.rdf4j</groupId>
+    <artifactId>ru.agentlab.rdf4j.parent</artifactId>
+    <version>4.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
 
-	<modules>
-		<module>ru.agentlab.rdf4j.sail.shacl</module>
-		<module>ru.agentlab.rdf4j.server</module>
-		<module>ru.agentlab.rdf4j.features</module>
-		<!--<module>ru.agentlab.rdf4j.jaxrs.tests.helpers</module>
-		<module>ru.agentlab.rdf4j.jaxrs.tests</module>
-		<module>distrib</module>-->
-	</modules>
+    <name>Agentlab RDF4J Parent</name>
+    <description>Agentlab RDF4J REST Server Parent Pom</description>
 
-	<profiles>
-		<profile>
-			<id>agentlab</id>
-			<distributionManagement>
-				<repository>
-					<id>agentlab</id>
-					<url>https://nexus.agentlab.ru/nexus/repository/maven-releases</url>
-				</repository>
-				<snapshotRepository>
-					<id>agentlab</id>
-					<url>https://nexus.agentlab.ru/nexus/repository/maven-snapshots</url>
-				</snapshotRepository>
-			</distributionManagement>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-source-plugin</artifactId>
-						<version>3.2.1</version>
-						<executions>
-							<execution>
-								<id>attach-sources</id>
-								<goals>
-									<goal>jar-no-fork</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-					<!--<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-javadoc-plugin</artifactId> 
-						<executions>
-							<execution>
-								<id>attach-javadocs</id>
-								<goals>
-									<goal>jar</goal> 
-								</goals>
-							</execution>
-						</executions>
-					</plugin> -->
-				</plugins>
-			</build>
-		</profile>
-		<profile>
-			<id>quick</id>
-			<properties>
-				<skipTests>true</skipTests>
-				<skipITs>true</skipITs>
-				<maven.test.skip>true</maven.test.skip>
-			</properties>
-		</profile>
-	</profiles>
+    <modules>
+        <module>ru.agentlab.rdf4j.sail.shacl</module>
+        <module>ru.agentlab.rdf4j.server</module>
+        <module>ru.agentlab.rdf4j.features</module>
+        <!--<module>ru.agentlab.rdf4j.jaxrs.tests.helpers</module>
+        <module>ru.agentlab.rdf4j.jaxrs.tests</module>
+        <module>distrib</module>-->
+    </modules>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<!-- When updating the version of Karaf, remember to copy from the distribution 
-			and then modify the files org.ops4j.pax.logging.cfg, org.ops4j.pax.web.cfg, 
-			org.apache.karaf.features.cfg; additionally, update the version of Karaf 
-			indicated in branding.properties (module st-console) -->
-		<karaf.version>4.3.0</karaf.version>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-storage</artifactId>
+                <type>pom</type>
+                <version>${rdf4j.osgi.version}</version>
+            </dependency>
 
-		<maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
-		<osgi.version>7.0.0</osgi.version>
-		<osgi.compendium.version>6.0.0</osgi.compendium.version>
-		<pax.exam.version>4.13.4</pax.exam.version>
-		<awaitility.version>3.1.6</awaitility.version>
-		<junit.version>4.13.1</junit.version>
-		<!-- Further used maven plugin versions; e.g. in the docs -->
-		<plugin.depends.version>1.4.0</plugin.depends.version>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>osgi.cmpn</artifactId>
+                <version>${osgi.compendium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>osgi.annotation</artifactId>
+                <version>${osgi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>osgi.core</artifactId>
+                <version>${osgi.version}</version>
+            </dependency>
 
-		<jackson.version>2.11.3</jackson.version>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>1.7.1</version>
+                <scope>test</scope>
+            </dependency>
 
-		<commons.cli.version>1.4</commons.cli.version>
-		<commons.fileupload.version>1.4</commons.fileupload.version>
-		<commons.io.version>2.8.0</commons.io.version>
-		<commons.codec.version>1.14</commons.codec.version>
-		<commons.lang3.version>3.11</commons.lang3.version>
-		<commons.text.version>1.9</commons.text.version>
-		<commons-beanutils.version>1.9.4</commons-beanutils.version>
-		<commons-collections.version>3.2.2</commons-collections.version>
-		<commons-collections4.version>4.4</commons-collections4.version>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>5.7.1</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
-		<httpclient.version>4.5.13</httpclient.version>
-		<httpcore.version>4.4.13</httpcore.version>
-		<spring.version>5.2.9.RELEASE_1</spring.version>
+    <profiles>
+        <profile>
+            <id>agentlab</id>
+            <distributionManagement>
+                <repository>
+                    <id>agentlab</id>
+                    <url>https://nexus.agentlab.ru/nexus/repository/maven-releases</url>
+                </repository>
+                <snapshotRepository>
+                    <id>agentlab</id>
+                    <url>https://nexus.agentlab.ru/nexus/repository/maven-snapshots</url>
+                </snapshotRepository>
+            </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!--<plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin> -->
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>quick</id>
+            <properties>
+                <skipTests>true</skipTests>
+                <skipITs>true</skipITs>
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+        </profile>
+    </profiles>
 
-		<spatial4j.version>0.7</spatial4j.version>
-		<jts.core.version>1.17.1</jts.core.version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <!-- When updating the version of Karaf, remember to copy from the distribution
+            and then modify the files org.ops4j.pax.logging.cfg, org.ops4j.pax.web.cfg,
+            org.apache.karaf.features.cfg; additionally, update the version of Karaf
+            indicated in branding.properties (module st-console) -->
+        <karaf.version>4.3.0</karaf.version>
 
-		<servlet.version>3.1.0</servlet.version>
-		<guava.version>29.0-jre</guava.version>
+        <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
+        <osgi.version>7.0.0</osgi.version>
+        <osgi.compendium.version>7.0.0</osgi.compendium.version>
+        <pax.exam.version>4.13.4</pax.exam.version>
+        <awaitility.version>3.1.6</awaitility.version>
+        <junit.version>4.13.1</junit.version>
+        <!-- Further used maven plugin versions; e.g. in the docs -->
+        <plugin.depends.version>1.4.0</plugin.depends.version>
 
-		<slf4j.version>1.7.30</slf4j.version>
-		<pax.logging.version>2.0.6</pax.logging.version>
-		<version.org.apache.logging.log4j>2.13.0</version.org.apache.logging.log4j>
+        <jackson.version>2.11.3</jackson.version>
 
-		<jsonldjava.version>0.13.2</jsonldjava.version>
-		<mapdb.version>1.0.8</mapdb.version>
+        <commons.cli.version>1.4</commons.cli.version>
+        <commons.fileupload.version>1.4</commons.fileupload.version>
+        <commons.io.version>2.8.0</commons.io.version>
+        <commons.codec.version>1.14</commons.codec.version>
+        <commons.lang3.version>3.11</commons.lang3.version>
+        <commons.text.version>1.9</commons.text.version>
+        <commons-beanutils.version>1.9.4</commons-beanutils.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
+        <commons-collections4.version>4.4</commons-collections4.version>
 
-		<jaxb.version>2.3.2</jaxb.version>
-		<opencsv.version>4.6</opencsv.version>
+        <httpclient.version>4.5.13</httpclient.version>
+        <httpcore.version>4.4.13</httpcore.version>
+        <spring.version>5.2.9.RELEASE_1</spring.version>
 
-		<dependency.jetty.version>9.4.31.v20200723</dependency.jetty.version>
-		<pax.web.version>7.3.9</pax.web.version>
-		<cxf.version>3.3.7</cxf.version>
-		<aries.blueprint.api.version>1.0.1</aries.blueprint.api.version>
-		<aries.blueprint.core.version>1.10.2</aries.blueprint.core.version>
-		<aries.whiteboard.version>1.0.7</aries.whiteboard.version>
-		<aries.blueprint.spring.version>0.6.0</aries.blueprint.spring.version>
+        <spatial4j.version>0.8</spatial4j.version>
+        <jts.core.version>1.18.1</jts.core.version>
 
-		<rdf4j.osgi.version>3.5.0-M1</rdf4j.osgi.version>
+        <servlet.version>3.1.0</servlet.version>
+        <guava.version>29.0-jre</guava.version>
+        <failureaccess.version>1.0.1</failureaccess.version>
 
-		<lucene.version>7.7.1</lucene.version>
-		<solr.version>7.7.1</solr.version>
-		<elasticsearch.version>6.6.2</elasticsearch.version>
-		<netty.version>4.1.32.Final</netty.version>
-	</properties>
+        <slf4j.version>1.7.30</slf4j.version>
+        <pax.logging.version>2.0.6</pax.logging.version>
+        <version.org.apache.logging.log4j>2.13.0</version.org.apache.logging.log4j>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.0.0-M3</version>
-				<executions>
-					<execution>
-						<id>enforce-maven</id>
-						<goals>
-							<goal>enforce</goal>
-						</goals>
-						<configuration>
-							<rules>
-								<requireMavenVersion>
-									<version>3.6.3</version>
-								</requireMavenVersion>
-								<requireJavaVersion>
-									<version>[11,)</version>
-								</requireJavaVersion>
-							</rules>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>org.apache.felix</groupId>
-					<artifactId>maven-bundle-plugin</artifactId>
-					<version>${maven-bundle-plugin.version}</version>
-					<extensions>true</extensions>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.8.1</version>
-					<configuration>
-						<fork>true</fork>
-						<source>11</source>
-						<target>11</target>
-						<encoding>utf8</encoding>
-					</configuration>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-install-plugin</artifactId>
-					<version>3.0.0-M1</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-resources-plugin</artifactId>
-					<version>3.1.0</version>
-				</plugin>
-				<plugin>
-					<groupId>org.codehaus.mojo</groupId>
-					<artifactId>build-helper-maven-plugin</artifactId>
-					<version>3.1.0</version>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-	</build>
+        <jsonldjava.version>0.13.2</jsonldjava.version>
+        <mapdb.version>1.0.9</mapdb.version>
 
-	<repositories>
-		<repository>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-			<id>agentlab-releases</id>
-			<url>https://nexus.agentlab.ru/nexus/repository/maven-releases</url>
-		</repository>
-		<repository>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<id>agentlab</id>
-			<url>https://nexus.agentlab.ru/nexus/repository/maven-snapshots</url>
-		</repository>
-		<repository>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<id>oss-sonatype-snapshots</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</repository>
-		<!-- Apache snapshots -->
-		<repository>
-			<id>apache-snapshots</id>
-			<name>Apache Snapshots Repository</name>
-			<url>http://repository.apache.org/content/groups/snapshots-group</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-		<!-- OPS4J SNAPSHOT repository -->
-		<repository>
-			<id>ops4j.sonatype.snapshots.deploy</id>
-			<name>OPS4J snapshot repository</name>
-			<url>https://oss.sonatype.org/content/repositories/ops4j-snapshots/</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
+        <jaxb.version>2.3.2</jaxb.version>
+        <opencsv.version>4.6</opencsv.version>
 
-	<pluginRepositories>
-		<!-- Apache snapshots -->
-		<pluginRepository>
-			<id>apache-snapshots</id>
-			<name>Apache Snapshots Repository</name>
-			<url>https://repository.apache.org/content/groups/snapshots-group</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
+        <dependency.jetty.version>9.4.31.v20200723</dependency.jetty.version>
+        <pax.web.version>7.3.9</pax.web.version>
+        <cxf.version>3.3.7</cxf.version>
+        <aries.blueprint.api.version>1.0.1</aries.blueprint.api.version>
+        <aries.blueprint.core.version>1.10.2</aries.blueprint.core.version>
+        <aries.whiteboard.version>1.0.7</aries.whiteboard.version>
+        <aries.blueprint.spring.version>0.6.0</aries.blueprint.spring.version>
+
+        <rdf4j.osgi.version>3.7.0</rdf4j.osgi.version>
+
+        <lucene.version>7.7.1</lucene.version>
+        <solr.version>7.7.1</solr.version>
+        <elasticsearch.version>6.8.14</elasticsearch.version>
+        <netty.version>4.1.32.Final</netty.version>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>15</maven.compiler.source>
+        <maven.compiler.target>15</maven.compiler.target>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.6.3</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>[11,)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>${maven-bundle-plugin.version}</version>
+                    <extensions>true</extensions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                    <configuration>
+                        <fork>true</fork>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>agentlab-releases</id>
+            <url>https://nexus.agentlab.ru/nexus/repository/maven-releases</url>
+        </repository>
+        <repository>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>agentlab</id>
+            <url>https://nexus.agentlab.ru/nexus/repository/maven-snapshots</url>
+        </repository>
+        <repository>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>oss-sonatype-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </repository>
+        <!-- Apache snapshots -->
+        <repository>
+            <id>apache-snapshots</id>
+            <name>Apache Snapshots Repository</name>
+            <url>http://repository.apache.org/content/groups/snapshots-group</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <!-- OPS4J SNAPSHOT repository -->
+        <repository>
+            <id>ops4j.sonatype.snapshots.deploy</id>
+            <name>OPS4J snapshot repository</name>
+            <url>https://oss.sonatype.org/content/repositories/ops4j-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <!-- Apache snapshots -->
+        <pluginRepository>
+            <id>apache-snapshots</id>
+            <name>Apache Snapshots Repository</name>
+            <url>https://repository.apache.org/content/groups/snapshots-group</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>

--- a/ru.agentlab.rdf4j.features/src/main/feature/feature.xml
+++ b/ru.agentlab.rdf4j.features/src/main/feature/feature.xml
@@ -159,7 +159,7 @@
 	<feature name="rdf4j-spring" version="${project.version}">
         <feature>ru.agentlab.rdf4j</feature>
         
-        <feature prerequisite="true" dependency="false">pax-web-http-whiteboard</feature>
+        <feature prerequisite="true" dependency="false" version="${pax.web.version}">pax-web-http-whiteboard</feature>
     	<!-- Web-Console -->
 		<feature prerequisite="true" dependency="false">webconsole</feature>
 		<feature prerequisite="true" dependency="false">war</feature>

--- a/ru.agentlab.rdf4j.server/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/ru.agentlab.rdf4j.server/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -53,6 +53,7 @@
 			<bn:bean factory-bean="commonAppConfig" factory-method="getDataDir"/>
 		</bn:constructor-arg >
 	</bn:bean>
+	<service id="localRepositoryManager" ref="rdf4jRepositoryManager" interface="org.eclipse.rdf4j.repository.manager.RepositoryManager"/>
 	<!-- INTERCEPTORS -->
 	<bn:bean id="rdf4jRepositoryInterceptor" class="org.eclipse.rdf4j.http.server.repository.RepositoryInterceptor">
 	<!--  scope="request" -->


### PR DESCRIPTION
На rdf4j 3.7.0 переход прошел безболезненно
Для того, чтобы OSGi-сервисам можно было импортировать `RepositoryManager`, [добавил](https://github.com/agentlab/rdf4j-karaf-server/commit/55bdfa3b295f5085d135d63fda2a3ebd6cc7ba3f) `<service/>` в blueprint-конфиг